### PR TITLE
AWS CF templates- add first architecture template 

### DIFF
--- a/AWS_CF_templates/simple_architecture.json
+++ b/AWS_CF_templates/simple_architecture.json
@@ -50,6 +50,11 @@
             "Type": "String",
             "Default": "IoTAppDataTableSimple",
             "Description": "Enter the name of DynamoDb data table"
+        },
+        "DataBaseTableRoleName": {
+            "Type": "String",
+            "Default": "IoTAppDynamoDBRoleSimple",
+            "Description": "Enter the name of DynamoDb data table role"
         }
     },
     "Resources": {
@@ -60,15 +65,28 @@
                 "TopicRulePayload": {
                     "RuleDisabled": "true",
                     "Sql": {
-                        "Fn::Sub": "SELECT * FROM {DataTopicName}"
+                        "Fn::Sub": [
+                            "SELECT * FROM '${topicName}'",
+                            {
+                                "topicName": {
+                                    "Ref": "DataTopicName"
+                                }
+                            }
+                        ]
                     },
                     "Actions": [
                         {
-                            "dynamoDBv2": {
-                                "putItem": {
-                                    "tableName": {
+                            "DynamoDBv2": {
+                                "PutItem": {
+                                    "TableName": {
                                         "Ref": "DataBaseTableName"
                                     }
+                                },
+                                "RoleArn": {
+                                    "Fn::GetAtt": [
+                                        "IoTAppDynamoDBRole",
+                                        "Arn"
+                                    ]
                                 }
                             }
                         }
@@ -97,7 +115,7 @@
                         "AttributeType": "N"
                     }
                 ],
-                "BillingMode":"PAY_PER_REQUEST",
+                "BillingMode": "PAY_PER_REQUEST",
                 "KeySchema": [
                     {
                         "AttributeName": "applicationId",
@@ -115,6 +133,26 @@
             "Metadata": {
                 "AWS::CloudFormation::Designer": {
                     "id": "5fb1cb83-4591-4722-86cf-b9f52658cf74"
+                }
+            }
+        },
+        "IoTAppDynamoDBRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "RoleName": {
+                    "Ref": "DataBaseTableRoleName"
+                },
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "iot.amazonaws.com"
+                            },
+                            "Action": "sts:AssumeRole"
+                        }
+                    ]
                 }
             }
         }

--- a/AWS_CF_templates/simple_architecture.json
+++ b/AWS_CF_templates/simple_architecture.json
@@ -1,0 +1,101 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Metadata": {
+        "AWS::CloudFormation::Designer": {
+            "287b7ae4-d46b-45ce-8209-a7c6f22dde4e": {
+                "size": {
+                    "width": 60,
+                    "height": 60
+                },
+                "position": {
+                    "x": 430,
+                    "y": 190
+                },
+                "z": 0,
+                "embeds": [],
+                "dependson": [
+                    "5fb1cb83-4591-4722-86cf-b9f52658cf74"
+                ]
+            },
+            "5fb1cb83-4591-4722-86cf-b9f52658cf74": {
+                "size": {
+                    "width": 60,
+                    "height": 60
+                },
+                "position": {
+                    "x": 700,
+                    "y": 190
+                },
+                "z": 0,
+                "embeds": []
+            },
+            "d9ee51e1-3211-470b-b4f0-b41a918164f8": {
+                "source": {
+                    "id": "287b7ae4-d46b-45ce-8209-a7c6f22dde4e"
+                },
+                "target": {
+                    "id": "5fb1cb83-4591-4722-86cf-b9f52658cf74"
+                },
+                "z": 1
+            }
+        }
+    },
+    "Parameters": {
+        "DataTopicName": {
+            "Type": "String",
+            "Default": "iot_app/iot_app",
+            "Description": "Enter the topic name for which you want to pass the data to data base"
+        },
+        "DataBaseTableName": {
+            "Type": "String",
+            "Default": "IoTAppDataTableSimple",
+            "Description": "Enter the name of DynamoDb data table"
+        }
+    },
+    "Resources": {
+        "IoTAppTopicRule": {
+            "Type": "AWS::IoT::TopicRule",
+            "Properties": {
+                "RuleName": "IoTAppToDataTableRule",
+                "TopicRulePayload": {
+                    "RuleDisabled": "true",
+                    "Sql": {
+                        "Fn::Sub": "SELECT * FROM {DataTopicName}"
+                    },
+                    "Actions": [
+                        {
+                            "dynamoDBv2": {
+                                "putItem": {
+                                    "tableName": {
+                                        "Ref": "DataBaseTableName"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "287b7ae4-d46b-45ce-8209-a7c6f22dde4e"
+                }
+            },
+            "DependsOn": [
+                "IoTAppDataTable"
+            ]
+        },
+        "IoTAppDataTable": {
+            "Type": "AWS::DynamoDB::Table",
+            "Properties": {
+                "TableName": {
+                    "Ref": "DataBaseTableName"
+                }
+            },
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "5fb1cb83-4591-4722-86cf-b9f52658cf74"
+                }
+            }
+        }
+    }
+}

--- a/AWS_CF_templates/simple_architecture.json
+++ b/AWS_CF_templates/simple_architecture.json
@@ -87,6 +87,27 @@
         "IoTAppDataTable": {
             "Type": "AWS::DynamoDB::Table",
             "Properties": {
+                "AttributeDefinitions": [
+                    {
+                        "AttributeName": "applicationId",
+                        "AttributeType": "S"
+                    },
+                    {
+                        "AttributeName": "time",
+                        "AttributeType": "N"
+                    }
+                ],
+                "BillingMode":"PAY_PER_REQUEST",
+                "KeySchema": [
+                    {
+                        "AttributeName": "applicationId",
+                        "KeyType": "HASH"
+                    },
+                    {
+                        "AttributeName": "time",
+                        "KeyType": "RANGE"
+                    }
+                ],
                 "TableName": {
                     "Ref": "DataBaseTableName"
                 }


### PR DESCRIPTION
created cloud formation template which enables the creation of architecture that assigns data from IoT mqtt topic to DynamoDB database 